### PR TITLE
Fix potential crash if userLocale key does not exist

### DIFF
--- a/spatial_filter.py
+++ b/spatial_filter.py
@@ -20,7 +20,7 @@
  *                                                                         *
  ***************************************************************************/
 """
-from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication
+from qgis.PyQt.QtCore import QLocale, QSettings, QTranslator, QCoreApplication
 
 import os.path
 
@@ -33,7 +33,7 @@ class SpatialFilter:
     def __init__(self, iface):
         self.iface = iface
         self.plugin_dir = os.path.dirname(__file__)
-        locale = QSettings().value('locale/userLocale')[0:2]
+        locale = QSettings().value('locale/userLocale', QLocale().name())[0:2]
         locale_path = os.path.join(self.plugin_dir, 'i18n', f'spatial_filter_{locale}.qm')
 
         if os.path.exists(locale_path):


### PR DESCRIPTION
Ported from https://github.com/g-sherman/Qgis-Plugin-Builder/pull/117 which never made it to the published Plugin Builder...

Reference: https://lists.osgeo.org/pipermail/qgis-user/2023-March/052727.html

By sheer luck I also had this happen in a training today when I wanted to quickly demo the plugin. No idea why...