### PR TITLE
Don't try to refresh filter geometry display if no filter is set

### DIFF
--- a/widgets.py
+++ b/widgets.py
@@ -415,7 +415,7 @@ class FilterToolbar(QToolBar):
         self.symbol = self.styleFilterButton.symbol().clone()
         self.saveFilterSymbol()
 
-        if self.showGeomStatus:
+        if self.showGeomStatus and self.controller.currentFilter:
             self.hideFilterGeom()
             self.showFilterGeom()
 


### PR DESCRIPTION
Plugin crashed if the user assigned a new style if no filter was currently set (e. g. after launching).