### PR TITLE
Add some padding around extent when zooming to filter geometry

### DIFF
--- a/widgets.py
+++ b/widgets.py
@@ -475,4 +475,5 @@ class FilterToolbar(QToolBar):
     def zoomToFilter(self):
         if self.controller.hasValidFilter():
             iface.mapCanvas().setExtent(self.controller.currentFilter.geometry.boundingBox())
+            iface.mapCanvas().zoomByFactor(1.05)
             iface.mapCanvas().refresh()

--- a/widgets.py
+++ b/widgets.py
@@ -474,6 +474,5 @@ class FilterToolbar(QToolBar):
 
     def zoomToFilter(self):
         if self.controller.hasValidFilter():
-            iface.mapCanvas().setExtent(self.controller.currentFilter.geometry.boundingBox())
-            iface.mapCanvas().zoomByFactor(1.05)
+            iface.mapCanvas().zoomToFeatureExtent(self.controller.currentFilter.geometry.boundingBox())
             iface.mapCanvas().refresh()


### PR DESCRIPTION
closes https://github.com/WhereGroup/spatial_filter/issues/17

The amount of padding is also a matter of taste, so please feel free to suggest a different factor 😉 



**This PR:**
![grafik](https://github.com/WhereGroup/spatial_filter/assets/20856381/d077b793-65c0-4c08-b46b-93e291c9792f)


**Before:**
![grafik](https://github.com/WhereGroup/spatial_filter/assets/20856381/af2e8e75-1e46-43fe-b897-85bb85f9eef8)


